### PR TITLE
Add migrate and healthcheck scripts

### DIFF
--- a/scripts/healthcheck.ts
+++ b/scripts/healthcheck.ts
@@ -1,0 +1,37 @@
+import { db } from "../server/db";
+import { users, books, userSessions, pricingCache } from "@shared/schema";
+
+async function runHealthcheck() {
+  try {
+    console.log("\u2705 Database connection is live.");
+
+    const [userCount] = await db.select({ count: db.fn.count() }).from(users);
+    const [bookCount] = await db.select({ count: db.fn.count() }).from(books);
+    const [sessionCount] = await db
+      .select({ count: db.fn.count() })
+      .from(userSessions);
+
+    console.log(`\uD83D\uDC64 Users: ${userCount.count}`);
+    console.log(`\uD83D\uDCDA Books: ${bookCount.count}`);
+    console.log(`\uD83D\uDD10 Sessions: ${sessionCount.count}`);
+
+    const recentPriceEntry = await db
+      .select()
+      .from(pricingCache)
+      .orderBy(pricingCache.updatedAt)
+      .limit(1);
+
+    if (recentPriceEntry.length) {
+      console.log("\uD83D\uDCB5 Pricing cache is populated.");
+    } else {
+      console.log("\u26A0\uFE0F  Pricing cache is empty.");
+    }
+
+    console.log("\uD83E\uDE7A Healthcheck complete.");
+  } catch (error) {
+    console.error("\u274C Healthcheck failed:", error);
+    process.exit(1);
+  }
+}
+
+runHealthcheck();

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,0 +1,15 @@
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import { db } from "../server/db";
+
+async function main() {
+  try {
+    console.log("\uD83D\uDD03 Running migrations...");
+    await migrate(db, { migrationsFolder: "./migrations" });
+    console.log("\u2705 Migrations complete.");
+  } catch (error) {
+    console.error("\u274C Migration failed:", error);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add `scripts/migrate.ts` for running Drizzle migrations
- add `scripts/healthcheck.ts` to inspect DB status

## Testing
- `npx tsx scripts/migrate.ts` *(fails: connect ENETUNREACH)*
- `npx tsx scripts/healthcheck.ts` *(fails: cannot read properties of undefined)*


------
https://chatgpt.com/codex/tasks/task_e_68427326fc688320b3fb24822183832d