### PR TITLE
Fix migrate and healthcheck scripts

### DIFF
--- a/scripts/healthcheck.ts
+++ b/scripts/healthcheck.ts
@@ -1,19 +1,24 @@
 import { db } from "../server/db";
 import { users, books, userSessions, pricingCache } from "@shared/schema";
+import { count } from "drizzle-orm";
 
 async function runHealthcheck() {
   try {
     console.log("\u2705 Database connection is live.");
 
-    const [userCount] = await db.select({ count: db.fn.count() }).from(users);
-    const [bookCount] = await db.select({ count: db.fn.count() }).from(books);
-    const [sessionCount] = await db
-      .select({ count: db.fn.count() })
+    const userCountRes = await db.select({ count: count() }).from(users);
+    const bookCountRes = await db.select({ count: count() }).from(books);
+    const sessionCountRes = await db
+      .select({ count: count() })
       .from(userSessions);
 
-    console.log(`\uD83D\uDC64 Users: ${userCount.count}`);
-    console.log(`\uD83D\uDCDA Books: ${bookCount.count}`);
-    console.log(`\uD83D\uDD10 Sessions: ${sessionCount.count}`);
+    const userCount = userCountRes?.[0];
+    const bookCount = bookCountRes?.[0];
+    const sessionCount = sessionCountRes?.[0];
+
+    console.log(`\uD83D\uDC64 Users: ${userCount?.count ?? 0}`);
+    console.log(`\uD83D\uDCDA Books: ${bookCount?.count ?? 0}`);
+    console.log(`\uD83D\uDD10 Sessions: ${sessionCount?.count ?? 0}`);
 
     const recentPriceEntry = await db
       .select()
@@ -21,7 +26,7 @@ async function runHealthcheck() {
       .orderBy(pricingCache.updatedAt)
       .limit(1);
 
-    if (recentPriceEntry.length) {
+    if (recentPriceEntry?.length) {
       console.log("\uD83D\uDCB5 Pricing cache is populated.");
     } else {
       console.log("\u26A0\uFE0F  Pricing cache is empty.");

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,5 +1,21 @@
-import { migrate } from "drizzle-orm/postgres-js/migrator";
-import { db } from "../server/db";
+import { migrate } from "drizzle-orm/neon-serverless/migrator";
+import { Pool, neonConfig } from "@neondatabase/serverless";
+import ws from "ws";
+import { drizzle } from "drizzle-orm/neon-serverless";
+import * as schema from "@shared/schema";
+
+neonConfig.webSocketConstructor = ws;
+
+const databaseUrl = process.env.DATABASE_URL || "";
+
+if (!databaseUrl) {
+  throw new Error(
+    "DATABASE_URL env variable is required. Run the script with DATABASE_URL=\u003cconnection-string\u003e"
+  );
+}
+
+const pool = new Pool({ connectionString: databaseUrl });
+const db = drizzle({ client: pool, schema });
 
 async function main() {
   try {


### PR DESCRIPTION
## Summary
- support DATABASE_URL input for migration script
- use neon serverless driver for migrations
- guard against undefined results in healthcheck script
- use drizzle `count` helper for database counts

## Testing
- `npm run check` *(fails: server/pricing-service.ts etc.)*
- `DATABASE_URL="" npx tsx scripts/migrate.ts` *(fails: DATABASE_URL env variable is required)*
- `DATABASE_URL="postgresql://user:pass@localhost:5432/db" npx tsx scripts/migrate.ts` *(fails: connection refused)*
- `DATABASE_URL="postgresql://user:pass@localhost:5432/db" npx tsx scripts/healthcheck.ts` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68427525c4fc83209d3060aa8b04e36d