### PR TITLE
Refactor components to use centralized apiRequest

### DIFF
--- a/client/src/components/delete-book-dialog.tsx
+++ b/client/src/components/delete-book-dialog.tsx
@@ -16,19 +16,9 @@ export default function DeleteBookDialog({ book, isOpen, onClose }: DeleteBookDi
 
   const deleteMutation = useMutation({
     mutationFn: async () => {
-      const token = localStorage.getItem('authToken');
-      const response = await fetch(`/api/books/${book.id}`, {
+      await apiRequest(`/api/books/${book.id}`, {
         method: 'DELETE',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json'
-        }
       });
-      
-      if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(errorText || 'Failed to delete book');
-      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/books'] });

--- a/client/src/components/edit-book-dialog.tsx
+++ b/client/src/components/edit-book-dialog.tsx
@@ -64,21 +64,12 @@ export default function EditBookDialog({ book, isOpen, onClose }: EditBookDialog
         type: 'COGS' // Fixed classification for V2
       };
 
-      const token = localStorage.getItem('authToken');
-      const response = await fetch(`/api/books/${book.id}`, {
+      const response = await apiRequest(`/api/books/${book.id}`, {
         method: 'PUT',
-        headers: { 
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
-        },
         body: JSON.stringify(updateData)
       });
-      
-      if (!response.ok) {
-        throw new Error('Failed to update book');
-      }
-      
-      return response.json();
+
+      return response;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/books'] });

--- a/client/src/hooks/use-pricing.ts
+++ b/client/src/hooks/use-pricing.ts
@@ -49,18 +49,9 @@ export function useUpdateBookPricing() {
   
   return useMutation({
     mutationFn: async (bookId: number) => {
-      const response = await fetch(`/api/books/${bookId}/pricing`, {
+      return await apiRequest(`/api/books/${bookId}/pricing`, {
         method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-        },
       });
-      
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-      
-      return response.json();
     },
     onSuccess: (data: any, bookId) => {
       // Invalidate and refetch book data


### PR DESCRIPTION
## Summary
- switch insecure fetch calls to apiRequest in pricing hook and dialogs

## Testing
- `npm run check` *(fails: TS errors in server/pricing-service.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6842863e7d448320862c1a90d84e1e2d