### PR TITLE
Fix dev scripts to prevent server duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,3 +381,5 @@ marketplace_accounts (id, user_id, platform, credentials, status)
 ## Known Security Issues
 
 - Moderate vulnerability in `esbuild` (GHSA-67mh-4wv8-2f99) via dependencies `drizzle-kit` and `vite`. Fix requires breaking update.
+
+**Development Note:** Never call backend scripts from within `client`. Use `npm run dev:server` separately when needed.

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "scryvault-client",
+  "private": true,
+  "scripts": {
+    "dev": "vite"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "NODE_ENV=development tsx server/index.ts",
     "dev:server": "NODE_ENV=development tsx server/index.ts",
     "dev:client": "cd client && npm run dev",
-    "dev:full": "concurrently \"npm run dev:client\" \"npm run dev:server\"",
+    "dev:full": "concurrently \"npm run dev:server\" \"npm run dev:client\"",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",


### PR DESCRIPTION
## Summary
- create a `client/package.json` with a simple Vite dev script
- update `dev:full` in the root `package.json` to start the server then the client
- document that backend scripts should never be called from inside `client`

## Testing
- `npm run check`
- `npm run build`
- `npm run dev:full` *(terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_68432609194c8320b033ea789d7f8203