### PR TITLE
Fix token refresh handling

### DIFF
--- a/client/src/hooks/use-auth.ts
+++ b/client/src/hooks/use-auth.ts
@@ -39,7 +39,7 @@ export function useAuth() {
 
   const validateToken = useCallback(async () => {
     setIsValidating(true);
-    const token = localStorage.getItem('authToken');
+    let token = localStorage.getItem("authToken") || "";
     
     if (!token) {
       setAuthState({
@@ -51,42 +51,98 @@ export function useAuth() {
       return false;
     }
 
-    try {
-      // Validate token with the /me endpoint
-      const response = await apiRequest<User>('/api/auth/me', {
-        method: 'GET'
+    const fetchProfile = async (authToken: string) => {
+      const res = await fetch("/api/auth/me", {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+          "Content-Type": "application/json",
+        },
+        credentials: "include",
       });
 
-      if (response) {
-        // Update user data in localStorage if it changed
-        localStorage.setItem('user', JSON.stringify(response));
-
-        setAuthState({
-          isAuthenticated: true,
-          user: response,
-          tokenValid: true,
-        });
-        setIsValidating(false);
-        return true;
-      } else {
-        throw new Error('Invalid response from server');
+      if (res.ok) {
+        return (await res.json()) as User;
       }
+
+      if (res.status === 401) {
+        return null;
+      }
+
+      throw new Error(await res.text());
+    };
+
+    try {
+      let profile = await fetchProfile(token);
+
+      if (!profile) {
+        const refreshToken = localStorage.getItem("refreshToken");
+
+        if (refreshToken) {
+          try {
+            const refreshRes = await fetch("/api/refresh-token", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ token: refreshToken }),
+              credentials: "include",
+            });
+
+            if (refreshRes.ok) {
+              const data = await refreshRes.json();
+              localStorage.setItem("authToken", data.accessToken);
+              localStorage.setItem("refreshToken", data.refreshToken);
+              token = data.accessToken;
+              profile = await fetchProfile(token);
+
+              if (profile) {
+                setAuthState({
+                  isAuthenticated: true,
+                  user: profile,
+                  tokenValid: true,
+                });
+                localStorage.setItem("user", JSON.stringify(profile));
+                setIsValidating(false);
+                return true;
+              }
+            }
+          } catch (refreshErr) {
+            console.error("Token refresh failed:", refreshErr);
+          }
+        }
+
+        // If refresh failed
+        clearAuthData();
+        setIsValidating(false);
+        if (token) {
+          toast({
+            title: "Session expired",
+            description: "Please log in again to continue.",
+            variant: "destructive",
+          });
+        }
+        return false;
+      }
+
+      // Success path
+      localStorage.setItem("user", JSON.stringify(profile));
+      setAuthState({
+        isAuthenticated: true,
+        user: profile,
+        tokenValid: true,
+      });
+      setIsValidating(false);
+      return true;
     } catch (error) {
-      console.error('Token validation failed:', error);
-      
-      // Clear invalid auth data
+      console.error("Token validation failed:", error);
       clearAuthData();
       setIsValidating(false);
-      
-      // Show error message if we had a token but it's now invalid
       if (token) {
         toast({
           title: "Session expired",
           description: "Please log in again to continue.",
-          variant: "destructive"
+          variant: "destructive",
         });
       }
-      
       return false;
     }
   }, [clearAuthData, toast]);

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -56,17 +56,14 @@ export async function apiRequest<T>(
   url: string,
   options: RequestInit = {}
 ): Promise<T | null> {
-  let token = localStorage.getItem('authToken');
-  
-  const makeRequest = async (authToken?: string) => {
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-      ...options.headers as Record<string, string>,
-    };
+  let token = localStorage.getItem("authToken");
 
-    if (authToken) {
-      headers['Authorization'] = `Bearer ${authToken}`;
-    }
+  const makeRequest = async (authToken?: string) => {
+    const headers: HeadersInit = {
+      ...(authToken && { Authorization: `Bearer ${authToken}` }),
+      "Content-Type": "application/json",
+      ...options.headers,
+    };
 
     return fetch(url, {
       ...options,

--- a/server/auth-routes.ts
+++ b/server/auth-routes.ts
@@ -183,8 +183,7 @@ router.post("/logout", async (req, res) => {
   }
 });
 
-// Refresh token
-router.post("/refresh", async (req, res) => {
+async function handleRefresh(req: any, res: any) {
   try {
     const { refreshToken } = req.body;
 
@@ -257,7 +256,12 @@ router.post("/refresh", async (req, res) => {
     console.error("[Auth] Refresh error:", error);
     res.status(401).json({ error: "Invalid refresh token" });
   }
-});
+}
+
+// Refresh token
+router.post("/refresh", handleRefresh);
+// Legacy or alternate endpoint
+router.post("/refresh-token", handleRefresh);
 
 // All routes below this line require a valid access token
 router.use(authenticateToken);


### PR DESCRIPTION
## Summary
- include auth token headers in the query client
- refresh tokens during auth validation via `/api/refresh-token`
- expose `/refresh-token` endpoint on the server

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68437463a1f483209018244f1a56e663