### PR TITLE
Fix admin role route guard and auth state

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -44,6 +44,33 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }
 
+function AdminRoute({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated, isValidating, authState } = useAuth();
+  const [, setLocation] = useLocation();
+
+  useEffect(() => {
+    if (
+      !isValidating &&
+      (!isAuthenticated() || authState.user?.role !== 'admin')
+    ) {
+      setLocation('/login');
+    }
+  }, [isAuthenticated, isValidating, authState.user, setLocation]);
+
+  if (isValidating) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div
+          className="w-8 h-8 border-4 border-t-transparent rounded-full animate-spin"
+          style={{ borderColor: 'var(--emerald-primary)', borderTopColor: 'transparent' }}
+        ></div>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}
+
 function Router() {
   const [location, setLocation] = useLocation();
   const { isAuthenticated } = useAuth();
@@ -99,9 +126,9 @@ function Router() {
           </ProtectedRoute>
         </Route>
         <Route path="/admin">
-          <ProtectedRoute>
+          <AdminRoute>
             <AdminPage />
-          </ProtectedRoute>
+          </AdminRoute>
         </Route>
 
       </Switch>

--- a/client/src/hooks/use-auth.ts
+++ b/client/src/hooks/use-auth.ts
@@ -4,9 +4,11 @@ import { useToast } from '@/hooks/use-toast';
 import { useState, useEffect, useCallback } from 'react';
 import type { User } from '@shared/schema';
 
+type AuthUser = Pick<User, 'id' | 'email' | 'role' | 'subscriptionTier'>;
+
 interface AuthState {
   isAuthenticated: boolean;
-  user: User | null;
+  user: AuthUser | null;
   tokenValid: boolean;
 }
 
@@ -95,12 +97,14 @@ export function useAuth() {
               profile = await fetchProfile(token);
 
               if (profile) {
+                const { id, email, role, subscriptionTier } = profile as User;
+                const sanitizedUser: AuthUser = { id, email, role, subscriptionTier };
                 setAuthState({
                   isAuthenticated: true,
-                  user: profile,
+                  user: sanitizedUser,
                   tokenValid: true,
                 });
-                localStorage.setItem("user", JSON.stringify(profile));
+                localStorage.setItem("user", JSON.stringify(sanitizedUser));
                 setIsValidating(false);
                 return true;
               }
@@ -124,10 +128,12 @@ export function useAuth() {
       }
 
       // Success path
-      localStorage.setItem("user", JSON.stringify(profile));
+      const { id, email, role, subscriptionTier } = profile as User;
+      const sanitizedUser: AuthUser = { id, email, role, subscriptionTier };
+      localStorage.setItem("user", JSON.stringify(sanitizedUser));
       setAuthState({
         isAuthenticated: true,
-        user: profile,
+        user: sanitizedUser,
         tokenValid: true,
       });
       setIsValidating(false);

--- a/server/auth-routes.ts
+++ b/server/auth-routes.ts
@@ -283,17 +283,18 @@ router.get("/me", async (req: AuthenticatedRequest, res) => {
       email: users.email,
       subscriptionTier: users.subscriptionTier,
       role: users.role,
-      createdAt: users.createdAt
+      createdAt: users.createdAt,
     })
-    .from(users)
-    .where(eq(users.id, req.user.id))
-    .limit(1);
+      .from(users)
+      .where(eq(users.id, req.user.id))
+      .limit(1);
 
     if (user.length === 0) {
       return res.status(404).json({ error: "User not found" });
     }
 
-    res.json(user[0]);
+    const { id, email, subscriptionTier, role, createdAt } = user[0];
+    res.json({ id, email, subscriptionTier, role, createdAt });
   } catch (error) {
     console.error("[Auth] Get profile error:", error);
     res.status(401).json({ error: "Invalid token" });


### PR DESCRIPTION
## Summary
- include role and other fields in `/auth/me` response
- preserve role in auth state
- add `AdminRoute` component to protect `/admin`

## Testing
- `npm run check`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684462e21b688320987a88d33582af20