### PR TITLE
Fix plugin path in Vite config

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,6 +1,6 @@
 
 import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react-swc";
+import react from "@vitejs/plugin-react";
 import path from "path";
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- use `@vitejs/plugin-react` instead of the missing `plugin-react-swc` in the client Vite config

## Testing
- `npm run check`
- `npm run check-env` *(fails: Missing required env vars)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844c5960bc08320835fcf8a8ceb073d